### PR TITLE
Added support for using Redis across hosts and processes

### DIFF
--- a/simrecorder/__init__.py
+++ b/simrecorder/__init__.py
@@ -2,7 +2,7 @@ from .datastore import InMemoryDataStore
 from .hdf_datastore import HDF5DataStore
 from .recorder import Recorder
 from .zarr_datastore import ZarrDataStore
-from .redis_datastore import RedisDataStore
+from .redis_datastore import RedisDataStore, RedisServer
 from .serialization import Serialization
 
-__all__ = ['Recorder', 'InMemoryDataStore', 'HDF5DataStore', 'ZarrDataStore', 'RedisDataStore', 'Serialization']
+__all__ = ['Recorder', 'InMemoryDataStore', 'HDF5DataStore', 'ZarrDataStore', 'RedisDataStore', 'RedisServer', 'Serialization']

--- a/simrecorder/redis_datastore.py
+++ b/simrecorder/redis_datastore.py
@@ -1,24 +1,40 @@
 from simrecorder.datastore import DataStore
 from simrecorder.serialization import Serialization, SerializationMixin
+import pickle
+
+import logging
+
+from numbers import Integral
+import os
 
 REDIS_PORT = 65535
+
+logger = logging.getLogger('simrecorder.redis_datastore')
 
 
 class RedisDataStore(DataStore, SerializationMixin):
     """
-    A datastore that persists all data to redis with the provided parameters
+    A datastore that connects to a redis server and stores and retrieves data from the
+    server. All configuration pertaining to the format of data stored in the database,
+    is to be specified in the RedisServer instance to which this connects.
+
+    :param server_host: The string identifying the host containing the redis server
+    :param redis_port: The port number on which the redis port is active
     """
 
-    def __init__(self,
-                 server_host,
-                 data_directory,
-                 serialization=Serialization.PICKLE,
-                 use_multiprocess_deserialization=False,
-                 use_compression=True):
+    def __init__(self, server_host, redis_port=REDIS_PORT):
 
         self.server_host = server_host
-        self.data_directory = data_directory
+        self.redis_port = redis_port
         self.rj = None
+
+        import redis
+        self.rj = redis.StrictRedis(host=self.server_host, port=self.redis_port)  # , decode_responses=True)
+        config_dict = self.get_config()['client']
+
+        serialization = config_dict['serialization']
+        use_multiprocess_deserialization = config_dict['use_multiprocess_deserialization']
+        use_compression = config_dict['use_compression']
 
         if serialization == Serialization.PICKLE:
             self._serialize = self._pickle_serialize
@@ -36,23 +52,10 @@ class RedisDataStore(DataStore, SerializationMixin):
 
         self.config = dict(
             server_host=server_host,
-            data_directory=data_directory,
+            redis_port=redis_port,
             serialization=str(serialization),
             use_multiprocess_deserialization=use_multiprocess_deserialization,
             use_compression=use_compression)
-
-    def connect(self):
-        import redis
-        from rediscontroller import is_redis_running, start_redis
-        if is_redis_running():
-            raise RuntimeError(
-                "Redis is already running (maybe from a previous experiment?). Did you forget to change the port?")
-
-        start_redis(data_directory=self.data_directory)
-
-        self.rj = redis.StrictRedis(host=self.server_host, port=REDIS_PORT)  # , decode_responses=True)
-        self.set('config', self.config)
-        return self
 
     def set(self, key, value):
         serialized_obj = self._compress(self._serialize(value))
@@ -72,6 +75,129 @@ class RedisDataStore(DataStore, SerializationMixin):
             results = self.rj.lrange(key, 0, -1)
             return self._deserialize_list(results)
 
-    def close(self):
+    def get_config(self):
+        """
+        Get's the client and server configuration from the database
+        The config is stored using uncompressed pickle so that clients can read the
+        config of any server independent of server configuration.
+        """
+        client_config_data = self.rj.get('client_config')
+        server_config_data = self.rj.get('server_config')
+
+        if client_config_data is not None:
+            client_config_dict = pickle.loads(client_config_data)
+            client_config_dict['serialization'] = getattr(Serialization, client_config_dict['serialization'])
+            server_config_dict = pickle.loads(server_config_data)
+        else:
+            raise RuntimeError("The Redis server at host {} and port {} has not been"
+                               " appropriately initialized. The client and server"
+                               " configurations cannot be found. (Maybe you haven't"
+                               " called the start() method on the server?)"
+                               .format(self.server_host, self.redis_port))
+
+        return dict(client=client_config_dict, server=server_config_dict)
+
+
+class RedisServer:
+    """
+    This is a Redis server instance that starts a redis server with a particular
+    configuration. The server can be started and stopped via it's start and stop
+    methods, or it may be used as a context manager
+
+    :param data_directory: The directory in which to start the redis server
+    :param redis_port: Either an interger representing the port number on which the
+        server operates, or the string 'random', in which case a random port is used
+    :param config_file_path: The path of the config file to use to setup the
+        server. If None, uses the default config file installed by the redis-
+        installer package. Note that daemonize must be set to true for any config
+        file that you may want to use.
+
+    :param serialization: The serialization type used by :class:`RedisDataStore`
+        instances to store data.
+    :param use_multiprocess_deserialization: Whether the :class:`RedisDataStore`
+        clients use multiprocessing to deserialize data from the database
+    :param use_compression: `bool` value, whether the :class:`RedisDataStore`
+        clients use compression when storing and retrieving data
+
+    The parameters `serialization` `use_multiprocess_deserialization`
+    `use_compression` are configuration options that affect the way the class
+    :class:`.RedisDataStore` handles the data. These options are termed as the
+    client configuration options. They are specified when creating the server as
+    this is the only way they can be recorded and enforced consistently across
+    clients. Any :class:`.RedisDataStore` instance which connects to the server
+    will read the configuration of the server
+
+    If the database is an existing database that is being appended to, then the
+    client configuration specified by the arguments is IGNORED and the existing one
+    in the database is used. This is to ensure the uniformity in the data presented
+    """
+
+    def __init__(self, data_directory, redis_port=REDIS_PORT, config_file_path=None,
+                 serialization=Serialization.PICKLE,
+                 use_multiprocess_deserialization=False,
+                 use_compression=True):
+        """
+        """
+        assert isinstance(redis_port, Integral) or \
+            (isinstance(redis_port, str) and redis_port == 'random'), \
+            ("redis_port should be either an interger representing the port number on which"
+             " the server operates, or the string 'random'. It is currently {}".format(redis_port))
+        assert os.path.isdir(data_directory), \
+            "The data_directory: {} is not a valid directory".format(data_directory)
+
+        self.data_directory = data_directory
+        self._redis_port = redis_port
+        self.config_file_path = config_file_path
+        self.redis_port = None  # only assigned once the server is started
+        self.rj = None
+
+        self.server_config = dict(
+            data_directory=data_directory,
+            redis_port=redis_port,
+            config_file_path=config_file_path)
+
+        self.client_config = dict(
+            serialization=str(serialization.name),
+            use_multiprocess_deserialization=use_multiprocess_deserialization,
+            use_compression=use_compression)
+
+    def start(self):
+        """
+        Start the redis server
+        """
+        import redis
+        from rediscontroller import is_redis_running, start_redis
+        if not isinstance(self._redis_port, str):
+            if is_redis_running(redis_port=self._redis_port):
+                raise RuntimeError(
+                    "Redis is already running at port {} (maybe from a previous experiment?). Did "
+                    "you forget to change the port?".format(self._redis_port))
+
+        self.redis_port = start_redis(data_directory=self.data_directory, redis_port=self._redis_port)
+        self.rj = redis.StrictRedis(host='localhost', port=self.redis_port)  # , decode_responses=True)
+        existing_client_config = self.rj.get('client_config')
+        self.rj.set('server_config', pickle.dumps(self.server_config, protocol=0))
+        if existing_client_config is None:
+            self.rj.set('client_config', pickle.dumps(self.client_config, protocol=0))
+        else:
+            logger.warn('Found existing database in directory %s, ignoring specified'
+                        ' client configuration', self.data_directory)
+
+    def stop(self):
+        """
+        Stop the redis server
+        """
         from rediscontroller import stop_redis
-        stop_redis(redis_host=self.server_host)
+        stop_redis(redis_port=self.redis_port)
+        self.redis_port = None
+        self.rj = None
+
+    def get_port(self):
+        return self.redis_port
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.stop()

--- a/simrecorder/redis_datastore.py
+++ b/simrecorder/redis_datastore.py
@@ -85,9 +85,9 @@ class RedisDataStore(DataStore, SerializationMixin):
         server_config_data = self.rj.get('server_config')
 
         if client_config_data is not None:
-            client_config_dict = json.loads(client_config_data)
+            client_config_dict = json.loads(client_config_data.decode('utf-8'))
             client_config_dict['serialization'] = getattr(Serialization, client_config_dict['serialization'])
-            server_config_dict = json.loads(server_config_data)
+            server_config_dict = json.loads(server_config_data.decode('utf-8'))
         else:
             raise RuntimeError("The Redis server at host {} and port {} has not been"
                                " appropriately initialized. The client and server"
@@ -177,8 +177,8 @@ class RedisServer:
 
         existing_client_config = self._rj.get('client_config')
         if existing_client_config is None:
-            self._rj.set('client_config', json.dumps(self.client_config, protocol=0))
-            self._rj.set('server_config', json.dumps(self.server_config, protocol=0))
+            self._rj.set('client_config', json.dumps(self.client_config))
+            self._rj.set('server_config', json.dumps(self.server_config))
         else:
             logger.warn('Found existing database in directory %s, ignoring specified'
                         ' client and server configuration', self.data_directory)

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -125,6 +125,7 @@ class TestDatastores(unittest.TestCase):
             recorder.close()
             ## END WRITE
 
+        with RedisServer(data_directory=self.data_dir):
             ## READ
             redis_datastore = RedisDataStore(server_host='localhost')
             recorder = Recorder(redis_datastore)
@@ -147,6 +148,7 @@ class TestDatastores(unittest.TestCase):
             recorder.close()
             ## END WRITE
 
+        with RedisServer(data_directory=self.data_dir):
             ## READ
             redis_datastore = RedisDataStore(server_host='localhost')
             recorder = Recorder(redis_datastore)

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from simrecorder import (HDF5DataStore, InMemoryDataStore, Recorder,
-                         RedisDataStore, ZarrDataStore)
+                         RedisDataStore, RedisServer, ZarrDataStore)
 
 
 class TestDatastores(unittest.TestCase):
@@ -114,47 +114,49 @@ class TestDatastores(unittest.TestCase):
         ## END READ
 
     def test_redisdatastore_list(self):
-        ## WRITE
-        redis_datastore = RedisDataStore(server_host='localhost', data_directory=self.data_dir)
-        recorder = Recorder(redis_datastore)
+        with RedisServer(data_directory=self.data_dir):
+            ## WRITE
+            redis_datastore = RedisDataStore(server_host='localhost')
+            recorder = Recorder(redis_datastore)
 
-        for i in range(self.n_arrays):
-            array = self.arrays[i]
-            recorder.record(self.key, array)
-        recorder.close()
-        ## END WRITE
+            for i in range(self.n_arrays):
+                array = self.arrays[i]
+                recorder.record(self.key, array)
+            recorder.close()
+            ## END WRITE
 
-        ## READ
-        redis_datastore = RedisDataStore(server_host='localhost', data_directory=self.data_dir)
-        recorder = Recorder(redis_datastore)
+            ## READ
+            redis_datastore = RedisDataStore(server_host='localhost')
+            recorder = Recorder(redis_datastore)
 
-        l = recorder.get_all(self.key)
-        l = np.array(l)
-        self.assertTrue((self.arrays == l).all())
+            l = recorder.get_all(self.key)
+            l = np.array(l)
+            self.assertTrue((self.arrays == l).all())
 
-        recorder.close()
-        ## END READ
+            recorder.close()
+            ## END READ
 
     def test_redisdatastore_single_value(self):
-        ## WRITE
-        redis_datastore = RedisDataStore(server_host='localhost', data_directory=self.data_dir)
-        recorder = Recorder(redis_datastore)
+        with RedisServer(data_directory=self.data_dir):
+            ## WRITE
+            redis_datastore = RedisDataStore(server_host='localhost')
+            recorder = Recorder(redis_datastore)
 
-        recorder.set(self.key, self.val1)
-        recorder.set(self.key, self.val)
-        recorder.close()
-        ## END WRITE
+            recorder.set(self.key, self.val1)
+            recorder.set(self.key, self.val)
+            recorder.close()
+            ## END WRITE
 
-        ## READ
-        redis_datastore = RedisDataStore(server_host='localhost', data_directory=self.data_dir)
-        recorder = Recorder(redis_datastore)
+            ## READ
+            redis_datastore = RedisDataStore(server_host='localhost')
+            recorder = Recorder(redis_datastore)
 
-        l = recorder.get(self.key)
-        l = np.array(l)
-        self.assertTrue((self.val == l).all())
+            l = recorder.get(self.key)
+            l = np.array(l)
+            self.assertTrue((self.val == l).all())
 
-        recorder.close()
-        ## END READ
+            recorder.close()
+            ## END READ
 
     def test_zarrdatastore_list(self):
         ## WRITE


### PR DESCRIPTION
Created a class `RedisServer` and `RedisDataStore`. The `RedisDataStore` only connects to an existing `RedisServer` and reads and writes data to it. The `RedisServer` is the one that receives all the configuration.